### PR TITLE
Lesson 06

### DIFF
--- a/06-TimeManagement/Makefile
+++ b/06-TimeManagement/Makefile
@@ -1,0 +1,18 @@
+KERNEL_DIR=$(BUILD_KERNEL)
+TARGET=timer
+
+obj-m:= $(TARGET).o
+
+all:
+	@if [ -z $(KERNEL_DIR) ]; then\
+        echo "Export BUILD_KERNEL first";\
+	else \
+		$(MAKE) -C $(KERNEL_DIR) M=$(shell pwd) modules;\
+    fi
+clean:
+	@rm -f *.o .*.cmd .*.flags *.mod.c *.order
+	@rm -f .*.*.cmd *.symvers *~ *.*~ TODO.*
+	@rm -f .cache.mk
+	@rm -fR .tmp*
+	@rm -rf .tmp_versions
+	

--- a/06-TimeManagement/timer.c
+++ b/06-TimeManagement/timer.c
@@ -12,15 +12,109 @@
 #define MODULE_TAG			"Timer"
 #define CLASS_NAME			"Timer"
 
+static unsigned long int interval;
+module_param(interval, ulong, 0444);
+MODULE_PARM_DESC(interval, "An interval in ms for periodic output in dmesg");
+static struct timer_list print_timer;
+
+
+static void update_print_timer(unsigned long time_ms)
+{
+	int ret;
+
+	if (time_ms) {
+		ret = mod_timer(&print_timer, jiffies + msecs_to_jiffies(interval));
+		if (!ret)
+			pr_debug("%s: Timer was started\n", MODULE_TAG);
+		else
+			pr_debug("%s: Timer was updated\n", MODULE_TAG);
+	} else {
+		ret = del_timer(&print_timer);
+		if (!ret)
+			pr_debug("%s: Inactive timer was stopped\n", MODULE_TAG);
+		else
+			pr_debug("%s: Active timer was stopped\n", MODULE_TAG);
+	}
+}
+
+static void print_timer_fn(unsigned long data)
+{
+	pr_info("%s: This is a timer callback\n", MODULE_TAG);
+
+	update_print_timer(interval);
+}
+
+static ssize_t last_read_show(struct class *class, struct class_attribute *attr, char *buf)
+{
+	return 0;
+}
+
+static ssize_t last_absolute_show(struct class *class, struct class_attribute *attr, char *buf)
+{
+	return 0;
+}
+
+static ssize_t print_interval_show(struct class *class, struct class_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%ld\n", interval);
+}
+
+static ssize_t print_interval_store(struct class *class, struct class_attribute *attr, const char *buf, size_t count)
+{
+	unsigned long temp;
+	int ret;
+
+	ret = kstrtoul(buf, 0, &temp);
+	if (ret < 0)
+		return ret;
+	interval = temp;
+
+	update_print_timer(interval);
+
+	return count;
+}
+
+
+CLASS_ATTR_RO(last_read);
+CLASS_ATTR_RO(last_absolute);
+CLASS_ATTR_RW(print_interval);
+
+static struct attribute *timer_class_attrs[] = {
+	&class_attr_last_read.attr,
+	&class_attr_last_absolute.attr,
+	&class_attr_print_interval.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(timer_class);
+
+static struct class module_class = {
+	.name = CLASS_NAME,
+	.owner = THIS_MODULE,
+	.class_groups = timer_class_groups,
+};
 
 static int __init mod_init(void)
 {
+	int ret;
+
+	ret = class_register(&module_class);
+	if (ret < 0) {
+		pr_err("%s: Can't register a class in sysfs\n", MODULE_TAG);
+		return ret;
+	}
+
+	setup_timer(&print_timer, print_timer_fn, 0);
+	update_print_timer(interval);
+
 	pr_info("%s: module loaded\n", MODULE_TAG);
 	return 0;
 }
 
 static void __exit mod_exit(void)
 {
+	update_print_timer(0);
+	class_unregister(&module_class);
+
 	pr_info("%s: module unloaded\n", MODULE_TAG);
 }
 

--- a/06-TimeManagement/timer.c
+++ b/06-TimeManagement/timer.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/errno.h>
+#include <linux/uaccess.h>
+#include <linux/slab.h>
+#include <linux/ctype.h>
+#include <linux/sysfs.h>
+#include <linux/device.h>
+
+#define MODULE_TAG			"Timer"
+#define CLASS_NAME			"Timer"
+
+
+static int __init mod_init(void)
+{
+	pr_info("%s: module loaded\n", MODULE_TAG);
+	return 0;
+}
+
+static void __exit mod_exit(void)
+{
+	pr_info("%s: module unloaded\n", MODULE_TAG);
+}
+
+module_init(mod_init);
+module_exit(mod_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A timer module for sysfs");
+MODULE_VERSION("1.0");
+MODULE_AUTHOR("Aleksandr Androsov <eelleekk@gmail.com>");

--- a/06-TimeManagement/timer.c
+++ b/06-TimeManagement/timer.c
@@ -4,10 +4,10 @@
 #include <linux/kernel.h>
 #include <linux/errno.h>
 #include <linux/uaccess.h>
-#include <linux/slab.h>
 #include <linux/ctype.h>
 #include <linux/sysfs.h>
 #include <linux/device.h>
+#include <linux/timekeeping.h>
 
 #define MODULE_TAG			"Timer"
 #define CLASS_NAME			"Timer"
@@ -17,6 +17,8 @@ module_param(interval, ulong, 0444);
 MODULE_PARM_DESC(interval, "An interval in ms for periodic output in dmesg");
 static struct timer_list print_timer;
 
+static unsigned long last_read;
+static struct timeval last_abs_time;
 
 static void update_print_timer(unsigned long time_ms)
 {
@@ -39,19 +41,42 @@ static void update_print_timer(unsigned long time_ms)
 
 static void print_timer_fn(unsigned long data)
 {
-	pr_info("%s: This is a timer callback\n", MODULE_TAG);
+	struct timespec  uptime;
+
+	get_monotonic_boottime(&uptime);
+	pr_info("%s: System Uptime: %d sec\n", MODULE_TAG, uptime.tv_sec);
 
 	update_print_timer(interval);
 }
 
 static ssize_t last_read_show(struct class *class, struct class_attribute *attr, char *buf)
 {
-	return 0;
+	int cnt;
+	unsigned long delta;
+
+	delta = jiffies - last_read;
+	last_read = jiffies;
+	delta = jiffies_to_msecs(delta)/1000;
+
+	cnt = scnprintf(buf, PAGE_SIZE, "%ld\n", delta);
+
+	return cnt;
 }
 
 static ssize_t last_absolute_show(struct class *class, struct class_attribute *attr, char *buf)
 {
-	return 0;
+	struct tm local_time;
+	int cnt;
+
+	time64_to_tm(last_abs_time.tv_sec, sys_tz.tz_minuteswest * 60, &local_time);
+
+	cnt = scnprintf(buf, PAGE_SIZE, "%d/%02d/%02d %02d:%02d:%02d\n",
+		local_time.tm_year + 1900, local_time.tm_mon, local_time.tm_mday,
+		local_time.tm_hour, local_time.tm_min, local_time.tm_sec);
+
+	do_gettimeofday(&last_abs_time);
+
+	return cnt;
 }
 
 static ssize_t print_interval_show(struct class *class, struct class_attribute *attr, char *buf)
@@ -105,6 +130,12 @@ static int __init mod_init(void)
 
 	setup_timer(&print_timer, print_timer_fn, 0);
 	update_print_timer(interval);
+
+	//Set a zero point for last_read
+	last_read = jiffies;
+
+	//Set a zero point for last_abs_time
+	do_gettimeofday(&last_abs_time);
 
 	pr_info("%s: module loaded\n", MODULE_TAG);
 	return 0;


### PR DESCRIPTION
Added a sysfs module code with various timer functions.
To build the module you should export the BUILD_KERNEL environment variable first.

The module creates the "**Timer**" class in /sys/class. The module provides 3 attributes assigned to the class.
**last_read** (ro) - attribute allows getting a passed time since the last reading of this attribute.
**last_absolute** (ro) - attribute allows getting the absolute time of the last reading of this attribute.
**print_interval** (rw) - attribute allows the module to print periodically into dmesg with level INFO with a given interval in ms. The default value of interval is 0, it means the print output is disabled.
You can also pass interval as a parameter at loading the module e.g. "interval=1000"
The module will print a system uptime.