### PR TITLE
Lesson 10

### DIFF
--- a/10-ConcurrencyAndSynchronization/Makefile
+++ b/10-ConcurrencyAndSynchronization/Makefile
@@ -1,0 +1,17 @@
+KERNEL_DIR=$(BUILD_KERNEL)
+TARGET=thread
+
+obj-m:= $(TARGET).o
+
+all:
+	@if [ -z $(KERNEL_DIR) ]; then\
+        echo "Export BUILD_KERNEL first";\
+	else \
+		$(MAKE) -C $(KERNEL_DIR) M=$(shell pwd) modules;\
+    fi
+clean:
+	@rm -f *.o .*.cmd .*.flags *.mod.c *.order
+	@rm -f .*.*.cmd *.symvers *~ *.*~ TODO.*
+	@rm -f .cache.mk
+	@rm -fR .tmp*
+	@rm -rf .tmp_versions

--- a/10-ConcurrencyAndSynchronization/thread.c
+++ b/10-ConcurrencyAndSynchronization/thread.c
@@ -3,18 +3,50 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
+#include <linux/kthread.h>
+#include <linux/delay.h>
+
+#define MODULE_TAG "threadmodule"
+
+//Different ways to create a thread
+#define CREATE_THREAD_EASY
 
 static int param = 5;
 module_param(param, int, 0444);
 MODULE_PARM_DESC(param, "Delay time. Default 5 sec");
 
-
+static int thrad_func(void *data)
+{
+	ssleep(2);
+	return 0;
+}
 
 static int __init tmod_init(void)
 {
-	pr_debug("Loading the test module\n");
+	struct task_struct *task; 
+	char task_name[TASK_COMM_LEN];
+	static int tnum = 0;
+	pr_debug("Loading %s\n", MODULE_TAG);
 
-	pr_debug("Test module loaded\n");
+#ifdef CREATE_THREAD_EASY
+	task = kthread_run(thrad_func, NULL, "%d:thread_%d", current->pid, tnum++);	
+#else
+	task = kthread_create(thrad_func, NULL, "%d:thread_%d", current->pid, tnum++);
+	if(!IS_ERR(task)){
+		wake_up_process(task);
+	}
+#endif
+
+	if(IS_ERR(task)){
+		return PTR_ERR(task);
+	}
+
+	get_task_comm(task_name, task);
+	pr_debug("Task %s is running\n", task_name);
+
+	ssleep(3);
+
+	pr_debug("%s loaded\n", MODULE_TAG);
 	return 0;
 }
 

--- a/10-ConcurrencyAndSynchronization/thread.c
+++ b/10-ConcurrencyAndSynchronization/thread.c
@@ -7,6 +7,7 @@
 #include <linux/delay.h>
 #include <linux/slab.h>
 #include <linux/list.h>
+#include <linux/rtmutex.h>
 
 #define MODULE_TAG "threadmodule"
 
@@ -27,20 +28,21 @@ struct thread_list_node {
 };
 static LIST_HEAD(threads_list);
 
-DEFINE_SPINLOCK(lock);
+DEFINE_RT_MUTEX(mutex);
 
 static int thrad_func(void *data)
 {
 	static char task_name[TASK_COMM_LEN];
 
 	while(!kthread_should_stop()){
-		if(spin_is_locked(&lock)){
-			pr_debug("Spinlock is locked...wait\n");
+		if(rt_mutex_is_locked(&mutex)){
+			pr_debug("RT Mutex is locked...wait\n");
 		}
-		spin_lock(&lock);
+
+		rt_mutex_lock(&mutex);
 		get_task_comm(task_name, current);
 		pr_debug("Hello! from %s\n", task_name);
-		spin_unlock(&lock);
+		rt_mutex_unlock(&mutex);
 
 		ssleep(1);
 	}

--- a/10-ConcurrencyAndSynchronization/thread.c
+++ b/10-ConcurrencyAndSynchronization/thread.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+#define DEBUG 1
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int param = 5;
+module_param(param, int, 0444);
+MODULE_PARM_DESC(param, "Delay time. Default 5 sec");
+
+
+
+static int __init tmod_init(void)
+{
+	pr_debug("Loading the test module\n");
+
+	pr_debug("Test module loaded\n");
+	return 0;
+}
+
+
+
+
+static void __exit tmod_exit(void)
+{
+	pr_debug("Test module unloaded\n");
+}
+
+
+module_init(tmod_init);
+module_exit(tmod_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Thread test module");
+MODULE_AUTHOR("Aleksandr Androsov <eelleekk@gmail.com>");


### PR DESCRIPTION
A simple driver which realize the creation of a thread in different ways such as kthread_create and kthread_run.
The module able to start **threadnum** threads. All created threads will work during **Twork** seconds. These parameters might pass to the module at loading.
Implemented two types of blocking spinlock and RT_mutex in order to prevent simultaneous access to shared resources.
To build the module you should first export the BUILD_KERNEL environment variable, that points to a kernel directory.
