### PR TITLE
Lesson 11: Interrupt handling

### DIFF
--- a/mpu6050/dts_binding.txt
+++ b/mpu6050/dts_binding.txt
@@ -1,3 +1,11 @@
+&pio {
+	mpu6050_pins: mpu6050_pinmux {
+		pins = "PA6";
+		function = "irq";
+		bias-pull-up;
+	};
+};
+
 
 &i2c0 {
 	status = "okay";
@@ -5,6 +13,11 @@
 		compatible = "gl,mpu6050";
 		reg = <0x68>;
 		status = "okay";
-		int-gpios=<&pio 0 6 1>;
+		
+		pinctrl-names = "default";
+		pinctrl-0 = <&mpu6050_pins>;
+
+		interrupt-parent = <&pio>;
+		interrupts = <0 6 2>
 	};
 };

--- a/mpu6050/dts_binding.txt
+++ b/mpu6050/dts_binding.txt
@@ -1,0 +1,10 @@
+
+&i2c0 {
+	status = "okay";
+	gl_gyro: gl_gyro@68 {
+		compatible = "gl,mpu6050";
+		reg = <0x68>;
+		status = "okay";
+		int-gpios=<&pio 0 6 1>;
+	};
+};

--- a/mpu6050/mpu6050-regs.h
+++ b/mpu6050/mpu6050-regs.h
@@ -2,12 +2,14 @@
 #define _MPU6050_REGS_H
 
 /* Registed addresses */
+#define REG_SAMPLERATE_DIV  0x19
 #define REG_CONFIG			0x1A
 #define REG_GYRO_CONFIG		0x1B
 #define REG_ACCEL_CONFIG	0x1C
 #define REG_FIFO_EN			0x23
 #define REG_INT_PIN_CFG		0x37
 #define REG_INT_ENABLE		0x38
+#define REG_INT_STATUS      0x39
 #define REG_ACCEL_XOUT_H	0x3B
 #define REG_ACCEL_XOUT_L	0x3C
 #define REG_ACCEL_YOUT_H	0x3D
@@ -29,5 +31,15 @@
 
 /* Register values */
 #define MPU6050_WHO_AM_I	0x68
+
+#define INT_PIN_CFG_ACTIVE_LOW          0x80
+#define INT_PIN_CFG_LATCH_INT_EN        0x20
+#define INT_PIN_CFG_STATUS_READ_CLEAR   0x10
+
+#define INT_EN_DATA_RDY                 0x01
+
+#define CONF_DLPF_CFG_4                 0x04
+
+#define GCON_FCHOICE_DLPF_EN            0x02
 
 #endif /* _MPU6050_REGS_H */

--- a/mpu6050/mpu6050.c
+++ b/mpu6050/mpu6050.c
@@ -3,6 +3,7 @@
 #include <linux/device.h>
 #include <linux/err.h>
 #include <linux/i2c.h>
+#include <linux/timer.h>
 #include <linux/i2c-dev.h>
 
 #include "mpu6050-regs.h"
@@ -126,7 +127,6 @@ static ssize_t accel_x_show(struct class *class,
 			    struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[0]);
 	return strlen(buf);
 }
@@ -135,7 +135,6 @@ static ssize_t accel_y_show(struct class *class,
 			    struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[1]);
 	return strlen(buf);
 }
@@ -144,7 +143,6 @@ static ssize_t accel_z_show(struct class *class,
 			    struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.accel_values[2]);
 	return strlen(buf);
 }
@@ -153,7 +151,6 @@ static ssize_t gyro_x_show(struct class *class,
 			   struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[0]);
 	return strlen(buf);
 }
@@ -162,7 +159,6 @@ static ssize_t gyro_y_show(struct class *class,
 			   struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[1]);
 	return strlen(buf);
 }
@@ -171,27 +167,25 @@ static ssize_t gyro_z_show(struct class *class,
 			   struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.gyro_values[2]);
 	return strlen(buf);
 }
 
-static ssize_t temp_show(struct class *class,
+static ssize_t temperature_show(struct class *class,
 			 struct class_attribute *attr, char *buf)
 {
 	mpu6050_read_data();
-
 	sprintf(buf, "%d\n", g_mpu6050_data.temperature);
 	return strlen(buf);
 }
 
-CLASS_ATTR(accel_x, 0444, &accel_x_show, NULL);
-CLASS_ATTR(accel_y, 0444, &accel_y_show, NULL);
-CLASS_ATTR(accel_z, 0444, &accel_z_show, NULL);
-CLASS_ATTR(gyro_x, 0444, &gyro_x_show, NULL);
-CLASS_ATTR(gyro_y, 0444, &gyro_y_show, NULL);
-CLASS_ATTR(gyro_z, 0444, &gyro_z_show, NULL);
-CLASS_ATTR(temperature, 0444, &temp_show, NULL);
+CLASS_ATTR_RO(accel_x);
+CLASS_ATTR_RO(accel_y);
+CLASS_ATTR_RO(accel_z);
+CLASS_ATTR_RO(gyro_x);
+CLASS_ATTR_RO(gyro_y);
+CLASS_ATTR_RO(gyro_z);
+CLASS_ATTR_RO(temperature);
 
 static struct class *attr_class;
 
@@ -258,7 +252,7 @@ static int mpu6050_init(void)
 		pr_err("mpu6050: failed to create sysfs class attribute temperature: %d\n", ret);
 		return ret;
 	}
-
+	
 	pr_info("mpu6050: sysfs class attributes created\n");
 
 	pr_info("mpu6050: module loaded\n");


### PR DESCRIPTION
This PR contains commits, that should make MPU6050 driver more interrupt-driven. The most recent working commit is 346008f. It retreives GPIO from device tree, configures it and receives corresponding interrupt. However, it has one issue: some interrupts are missing sometimes (see log analyzer screenshot, IRQ and SCA/SDL lines).
![screenshot from 2019-01-13 16-01-31](https://user-images.githubusercontent.com/5807480/51087257-90c70100-1759-11e9-8efb-b0e53537dc33.png)
Commit 5fdef10 is attempt to get rid of GPIO configuration code inside driver and move it to device tree. It doesn't work due to errors while driver probing: 

> [   33.882798] mpu6050: loading out-of-tree module taints kernel.
 [   33.883546] irq: type mismatch, failed to map hwirq-38 for /soc/interrupt-controller@01c81000!

Any comments appreciated.